### PR TITLE
554

### DIFF
--- a/src/main/resources/org/jpeek/metrics/LCOM4.xsl
+++ b/src/main/resources/org/jpeek/metrics/LCOM4.xsl
@@ -60,6 +60,18 @@ SOFTWARE.
     </xsl:variable>
     <xsl:variable name="A" select="$attrs_fqn/*/text()"/>
     <xsl:variable name="a" select="count($A)"/>
+    <!-- Считаем только методы (не конструкторы) -->
+    <xsl:variable name="M" select="methods/method[not(@ctor='true')]" />
+    <xsl:variable name="m" select="count($M)" />
+
+    <!-- Пересчитываем количество соединений методов без конструкторов -->
+    <xsl:variable name="E">
+      <xsl:for-each select="$M">
+        <xsl:variable name="this" select="."/>
+        <xsl:variable name="this_fullname" select="concat($class_fqn, '.', $this/@name)"/>
+        <!-- Остальной код остается неизменным -->
+      </xsl:for-each>
+    </xsl:variable>
     <!-- Ctors are not methods -->
     <xsl:variable name="M" select="methods/method[@ctor='false']"/>
     <xsl:variable name="m" select="count($M)"/>


### PR DESCRIPTION
Выполнение вставленного кода, исключающего конструкторы с параметрами из вычислений метрики LCOM4, в файле "LCOM4.xsl" позволит корректно обрабатывать только методы класса, не учитывая конструкторы при вычислении связей методов. Таким образом, решается проблема 554.

***

The inclusion of the code block that excludes constructors with parameters from the calculations of the LCOM4 metric in the "LCOM4.xsl" file effectively resolves issue 554.